### PR TITLE
Fix for some deprecated endpoints

### DIFF
--- a/custom_components/binance_pool/__init__.py
+++ b/custom_components/binance_pool/__init__.py
@@ -428,7 +428,7 @@ class BinanceDataWallet(DataUpdateCoordinator):
             tasks = [
                 self.client.async_get_capital_balances(),
                 self.client.async_get_funding_balances(),
-                self.client.get_lending_account(),
+                self.client.get_simple_earn_account(),
                 self.client.get_all_tickers()
             ]
             
@@ -451,8 +451,6 @@ class BinanceDataWallet(DataUpdateCoordinator):
 
 
             if savings:
-                savings.pop("positionAmountVos", None)
-    
                 self.savings = savings
                 _LOGGER.debug(f"Savings data updated from binance.{self.tld}")
 

--- a/custom_components/binance_pool/manifest.json
+++ b/custom_components/binance_pool/manifest.json
@@ -5,11 +5,11 @@
   "issue_tracker": "https://github.com/shammysha/homeassistant-binance-pool/issues",
   "dependencies": [],
   "config_flow": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "codeowners": [
     "@shammysha"
   ],
   "requirements": [
-    "python-binance==1.0.10"
+    "python-binance>=1.0.17"
   ]
 }


### PR DESCRIPTION
python-binance version up to 1.0.17
landing endpoint replaced with get_simple_earn_account
version up